### PR TITLE
Updated Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 
 VERSION = $(shell git describe --tags)
 OUTPUT_JS = 'amazon-connect-$(VERSION).js'
+all: $(OUTPUT_JS)
 
 SOURCE_FILES = src/aws-client.js \
 					src/sprintf.js \


### PR DESCRIPTION
The Makefile in the latest version is wrong. It specifies the default goal is ‘all’, but ‘all’ is not defined. I have fixed it.

*Issue #, if available:*

*Description of changes:* I have added the following statement 
all: $(OUTPUT_JS)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
